### PR TITLE
38 be add date start and end times to event response

### DIFF
--- a/app/graphql/mutations/create_event.rb
+++ b/app/graphql/mutations/create_event.rb
@@ -19,8 +19,10 @@ module Mutations
     argument :host, Integer, required: true
     argument :game, Integer, required: true
     argument :gameType, String, required: true
+    argument :startTime, String, required: true
+    argument :endTime, String, required: true
 
-    def resolve(date:, address:, city:, state:, zip:, title:, description:, host:, game:, gameType:)
+    def resolve(date:, address:, city:, state:, zip:, title:, description:, host:, game:, gameType:, startTime:, endTime:)
       event = Event.new(
         date:,
         address:,
@@ -31,7 +33,9 @@ module Mutations
         description:,
         host_id: host.to_i,
         game: game.to_i,
-        game_type: gameType
+        game_type: gameType,
+        start_time: startTime,
+        end_time: endTime
       )
 
       if event.save

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -24,6 +24,8 @@ module Types
     field :game_details, Types::GameType
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :start_time, String
+    field :end_time, String
 
     def attendees
       object.users

--- a/db/migrate/20230711213745_add_details_to_events.rb
+++ b/db/migrate/20230711213745_add_details_to_events.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# This adds start time and end time to events
+class AddDetailsToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :start_time, :string
+    add_column :events, :end_time, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_10_000059) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_11_213745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,6 +30,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_10_000059) do
     t.float "lon"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "start_time"
+    t.string "end_time"
   end
 
   create_table "games", force: :cascade do |t|

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -15,5 +15,7 @@ FactoryBot.define do
     game_type { Faker::Game.genre }
     lat { Faker::Address.latitude }
     lon { Faker::Address.longitude }
+    start_time { Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default).split(' ')[4] }
+    end_time { Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default).split(' ')[4] }
   end
 end

--- a/spec/graphql/mutations/events/create_an_event_spec.rb
+++ b/spec/graphql/mutations/events/create_an_event_spec.rb
@@ -24,6 +24,8 @@ module Mutations
           expect(result['data']['createEvent']['event']['hostId']).to eq(event.host_id)
           expect(result['data']['createEvent']['event']['game']).to eq(event.game)
           expect(result['data']['createEvent']['event']['gameType']).to eq(event.game_type)
+          expect(result['data']['createEvent']['event']['startTime']).to eq(event.start_time)
+          expect(result['data']['createEvent']['event']['endTime']).to eq(event.end_time)
         end
 
         it 'returns an error if missing a required field' do
@@ -49,7 +51,9 @@ module Mutations
               description: "We'll be playing caracasonne for 9 hours",
               host: 4744564,
               game: 97833646,
-              gameType: "board game"
+              gameType: "board game",
+              startTime: "12:00",
+              endTime: "15:00"
             }) {
               event {
                 id
@@ -63,6 +67,8 @@ module Mutations
                 hostId
                 game
                 gameType
+                startTime
+                endTime
               }
             }
           }
@@ -80,7 +86,10 @@ module Mutations
               description: "We'll be playing caracasonne for 9 hours",
               host: 4744564,
               game: 97833646,
-              gameType: "board game"
+              gameType: "board game",
+              startTime: "12:00",
+              endTime: "15:00"
+
             }) {
               event {
                 id
@@ -94,6 +103,8 @@ module Mutations
                 hostId
                 game
                 gameType
+                startTime
+                endTime
               }
             }
           }


### PR DESCRIPTION
## Changes
- This PR closes #38 
- chore: added start time and end time to event mutation
- chore: added start time and end time to event type
- refactor: add times to the events table
- refactor: added times to the events factory
- test: added tests for time 

## Type of Changes
- [x] new feature
- [ ] setup
- [x] chore
- [ ] bug fix
- [x] refactor
- [ ] other: 

## Checklist
- [x] Tests added for new functionality
- [x] All other tests are also passing (please note if not) 
  - Current coverage %: 97.76

## Number of reviewers
- [x] 1
- [ ] 2
- [ ] 3

## Emoji or GIF about how you feel rn (optional)
https://media.giphy.com/media/ZF9bnuIder0fhsvloR/giphy.gif
