### PR TITLE
feat: Update error message for user trying to join event already joined

### DIFF
--- a/app/graphql/mutations/create_user_event.rb
+++ b/app/graphql/mutations/create_user_event.rb
@@ -20,6 +20,8 @@ module Mutations
 
       if user_event.save
         { user_event:, errors: [] }
+      elsif user_event.user_id == userId
+        raise GraphQL::ExecutionError, "Already joined event."
       else
         { user_event: nil, errors: user_event.errors.full_messages }
       end

--- a/spec/graphql/mutations/events/join_an_event_spec.rb
+++ b/spec/graphql/mutations/events/join_an_event_spec.rb
@@ -34,7 +34,7 @@ module Mutations
 
           response = JSON.parse(@response.body, symbolize_names: true)
 
-          expect(response[:errors][0][:message]).to eq('Cannot return null for non-nullable field CreateUserEventPayload.userEvent')
+          expect(response[:errors][0][:message]).to eq('Already joined event.')
         end
       end
 


### PR DESCRIPTION
## Changes
- This PR closes #
- Edits error message for when a user is already joined an event

## Type of Changes
- [x] new feature
- [ ] setup
- [ ] chore
- [ ] bug fix
- [x] refactor
- [ ] other: 

## Checklist
- [x] Tests added for new functionality
- [x] All other tests are also passing (please note if not) 
  - Current coverage %: 

## Number of reviewers
- [x] 1
- [ ] 2
- [ ] 3

## Emoji or GIF about how you feel rn (optional)
https://media1.giphy.com/media/PzphqmOehZDKwCmtke/200.webp?cid=ecf05e47ez74jxvhbkzpacmnx7reowirhz8t4tl11laorewt&ep=v1_gifs_search&rid=200.webp&ct=g